### PR TITLE
Pin and update Bundler to 2.4.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,12 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - uses: actions/setup-ruby@v1
+    - uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.6
     - name: Install dependencies
       run: |
-        gem install bundler
+        gem install bundler -v '~> 2.4.0'
         bundle install
     - name: Run lint
       run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ WORKDIR /app
 COPY Gemfile* /app/
 COPY *.gemspec /app/
 
-RUN gem install bundler
+RUN gem install bundler -v '~> 2.4.0'
 RUN bundle install --without development
 
 COPY . /app

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,7 +53,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (~> 1.16)
+  bundler (~> 2.4)
   minitest (~> 5.0)
   pry (~> 0.11.0)
   rake (~> 10.0)
@@ -61,4 +61,4 @@ DEPENDENCIES
   stations-human-diff!
 
 BUNDLED WITH
-   1.17.3
+   2.4.22

--- a/stations-human-diff.gemspec
+++ b/stations-human-diff.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler",  "~> 1.16"
+  spec.add_development_dependency "bundler",  "~> 2.4"
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "pry",      "~> 0.11.0"
   spec.add_development_dependency "rake",     "~> 10.0"


### PR DESCRIPTION
Bundler's 2.5 branch is incompatible with Ruby versions before 3, with the 2.4 branch being the last one to support Ruby 2.6.

The Dockerfile didn't specify a Bundler version, this is fixed and the required version is now updated in the Gemfile/.gemspec.